### PR TITLE
Make library search more Julian

### DIFF
--- a/src/ModernGL.jl
+++ b/src/ModernGL.jl
@@ -2,7 +2,7 @@ module ModernGL
 
 function getprocaddress(glFuncName::String)
     push!(Sys.DL_LOAD_PATH, "/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/")
-    const OpenGLLib = find_library("libGL", "opengl32", "/System/Library/Frameworks/OpenGL.framework/OpenGL")
+    const OpenGLLib = find_library(["libGL", "opengl32", "/System/Library/Frameworks/OpenGL.framework/OpenGL"])
     @linux? (
         ccall((:glXGetProcAddress, OpenGLLib), Ptr{Void}, (Ptr{Uint8},), glFuncName)
         :


### PR DESCRIPTION
The find_library() function (http://docs.julialang.org/en/latest/stdlib/base/?highlight=find_library#Base.find_library) will search in a few extra locations, making the process a bit more user and OS friendly (found this in @jayschwa's very nice GLFW repository: https://github.com/jayschwa/GLFW.jl/blob/glfw3/src/GLFW.jl). I've also included an additional search path that appears to be necessary on OS X 10.9.

Is there also a way to test if we are on FreeBSD? Julia works fine there and OpenGL is available there, but the current OS check error would indicate otherwise to a new user. To be safe, I've added an additional "@unix?" check that won't trigger if detection of Linux or OS X occurs first, but should (I think) trigger if the user is on FreeBSD.

Best,
Rob
