### PR TITLE
Fix GLsizei mapping

### DIFF
--- a/src/glTypes.jl
+++ b/src/glTypes.jl
@@ -19,7 +19,7 @@ typealias GLhalf                                                      Cushort
 typealias GLenum                                                      Cuint
 typealias GLboolean                                                   Cuchar
 typealias GLclampf                                                    Cfloat
-typealias GLsizei                                                     Csize_t
+typealias GLsizei                                                     Cint
 typealias GLsync                                                      Ptr{Void}
 typealias GLuint64                                                    Culonglong
 typealias GLclampd                                                    Cdouble


### PR DESCRIPTION
This was causing a bug for me in GLUtil that caused your GLPlot demo to crash.
