### PR TITLE
test: fix test for non-OSX

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,11 +148,13 @@ end
 GLFW.Init()
  
 # OS X-specific GLFW hints to initialize the correct version of OpenGL
+@osx_only begin
     GLFW.WindowHint(GLFW.CONTEXT_VERSION_MAJOR, 3)
     GLFW.WindowHint(GLFW.CONTEXT_VERSION_MINOR, 2)
     GLFW.WindowHint(GLFW.OPENGL_PROFILE, GLFW.OPENGL_CORE_PROFILE)
     GLFW.WindowHint(GLFW.OPENGL_FORWARD_COMPAT, GL_TRUE)
- 
+end
+
 # Create a windowed mode window and its OpenGL context
 window = GLFW.CreateWindow(600, 600, "OpenGL Example")
  


### PR DESCRIPTION
The block is indented, and the comment mentions it's for OSX. Without this, on both Windows and a Linux VM I get the error (except for path, which obviously varies):

```
ERROR: WGL: OpenGL profile requested but WGL_ARB_create_context_profile is unavailable
 in error at error.jl:21
while loading C:\Users\patrick\.julia\v0.3\ModernGL\test\runtests.jl, in expression starting on line 157
```

This fixes the Windows case, and I suspect also the Linux case but I haven't verified.
