### PR TITLE
add debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+deps/deps.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ dist: trusty
 julia:
   - 0.6
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
+
 notifications:
   email: false
 addons:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ OpenGL bindings for OpenGL 3.0 and upwards. As OpenGL 3.0 has a lot of overlaps 
 
 The philosophy is to keep this library strictly a low-level wrapper, so you won't find any error handling (besides for the function loading itself) or abstractions in this package.
 
+### Debugging
+
+You can rebuild ModernGL to include debug error checks:
+```Julia
+ENV["MODERNGL_DEBUGGING"] = "true"; Pkg.build("ModernGL")
+# or to get back the default behaviour:
+ENV["MODERNGL_DEBUGGING"] = "false"; Pkg.build("ModernGL")
+```
+
 ### Installation notes
 There are no dependencies, besides the graphic driver. If you have any problems, you should consider updating the driver first.
 
@@ -38,7 +47,7 @@ getProcAddress can be changed like this:
 using ModernGL
 
 function ModernGL.getprocaddress(name::ASCIIString)
-	# for example change it to GLUT 
+	# for example change it to GLUT
 	glutGetProcAddress(name)
 end
 ```
@@ -53,4 +62,4 @@ It seems, that there is actually no good way of testing if a function is support
 Credits go certainly to the OpenGL.jl ([rennis250](https://github.com/rennis250) && [o-jasper](https://github.com/o-jasper)) package, where I have all the OpenGL definitions from.
 Special thanks to rennis250 for all the support! :)
 
-Also, I have to thank for the constructive discussion on Julia-Users, where I got a good solution for the function pointer loading (final solution was from [vtjnash](https://github.com/vtjnash) and got replaced by [aaalexandrov's](https://github.com/aaalexandrov/) solution which doubled the speed). 
+Also, I have to thank for the constructive discussion on Julia-Users, where I got a good solution for the function pointer loading (final solution was from [vtjnash](https://github.com/vtjnash) and got replaced by [aaalexandrov's](https://github.com/aaalexandrov/) solution which doubled the speed).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,11 @@ notifications:
     on_build_failure: false
     on_build_status_changed: false
 
+matrix:
+  allow_failures:
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
 install:
   - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
 # Download most recent Julia Windows binary

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,4 @@
+debug_level = get(ENV, "MODERNGL_DEBUGGING", "false") == "true"
+open(joinpath(@__DIR__, "deps.jl"), "w") do io
+    println(io, "const enable_opengl_debugging = $debug_level")
+end

--- a/deps/deps.jl
+++ b/deps/deps.jl
@@ -1,0 +1,1 @@
+const enable_opengl_debugging = false

--- a/src/functionloading.jl
+++ b/src/functionloading.jl
@@ -13,7 +13,7 @@ function debug_opengl_expr(func_name, args)
             err = glGetError()
             if err != GL_NO_ERROR
                 arguments = gl_represent.(tuple($(args...)))
-                error("OpenGL call to $($func_name), with arguments: $(arguments)
+                warn("OpenGL call to $($func_name), with arguments: $(arguments)
                 Failed with error: $(GLENUM(err).name).")
             end
         end


### PR DESCRIPTION
After running into the third platform, that had modern drivers but didn't fully support the standard OpenGL debug callback, I finally just went for the simple solution of optionally adding a glGetError to all function calls.
One can change the debugging behaviour via  `ENV["MODERNGL_DEBUGGING"] = "true";Pkg.build("ModernG")`. 
The dynamic, but still overheadless version with reincluding all functions after changing the debug level segfaulted for me in the GC :D Not sure if julia isn't ready to reinclude ~2000 functions, or if I was doing something stupid... Anyways, this is good enough in my eyes, so I can't be bothered to debug this further ;) 
cc @louisponet 
