### PR TITLE
Add Map/Unmap named buffer functions

### DIFF
--- a/src/glFunctions.jl
+++ b/src/glFunctions.jl
@@ -547,3 +547,4 @@
 @glfunc glUniform4f(location::GLint, v0::GLfloat, v1::GLfloat, v2::GLfloat, v3::GLfloat)::Cvoid
 @glfunc glMapBuffer(target::GLenum, access::GLenum)::Ptr{Cvoid}
 @glfunc glMapNamedBuffer(buffer::GLuint, access::GLenum)::Ptr{Cvoid}
+@glfunc glUnmapNamedBuffer(buffer::GLuint)::GLboolean

--- a/src/glFunctions.jl
+++ b/src/glFunctions.jl
@@ -546,3 +546,4 @@
 @glfunc glDepthRangef(n::GLfloat, f::GLfloat)::Cvoid
 @glfunc glUniform4f(location::GLint, v0::GLfloat, v1::GLfloat, v2::GLfloat, v3::GLfloat)::Cvoid
 @glfunc glMapBuffer(target::GLenum, access::GLenum)::Ptr{Cvoid}
+@glfunc glMapNamedBuffer(buffer::GLuint, access::GLenum)::Ptr{Cvoid}


### PR DESCRIPTION
Adds `glMapNamedBuffer` and `glUnmapNamedBuffer` (see https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml and https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml).

I don't know if something was blocking this (particularly if the policy is to accept every modern function even if it's only present on OpenGL 4.5). I don't have experience with Julia or with ModernGL, but I ran into this problem by trying to use them and with this patch it works.

Hope it helps, and thank you for making this package, using OpenGL with Julia is awesome :smiley: 