### PR TITLE
Update glTypes.jl

### DIFF
--- a/src/glTypes.jl
+++ b/src/glTypes.jl
@@ -1,7 +1,7 @@
 #all OpenGL Types
 const GLCvoid = Cvoid
 const GLint = Cint
-const GLsizeiptr = Cint
+const GLsizeiptr = Cssize_t
 const Pointer = Ptr{Cvoid}
 const GLhalfNV = Cushort
 const GLshort = Cshort
@@ -19,7 +19,7 @@ const GLhalf = Cushort
 const GLenum = Cuint
 const GLboolean = Cuchar
 const GLclampf = Cfloat
-const GLsizei = Cint
+const GLsizei = Cssize_t
 const GLsync = Ptr{Cvoid}
 const GLuint64 = Culonglong
 const GLclampd = Cdouble


### PR DESCRIPTION
Suggested change by @CarpeNecopinum on slack
"some types that should be 64bit on 64bit systems are in fact 32bit, thus making it impossible to have buffers >2/4 GiB"