### PR TITLE
remove deps/deps.jl

### DIFF
--- a/deps/deps.jl
+++ b/deps/deps.jl
@@ -1,1 +1,0 @@
-const enable_opengl_debugging = false


### PR DESCRIPTION
Fixes https://github.com/JuliaGL/ModernGL.jl/issues/52 . 
`deps/deps.jl` is mentioned in https://github.com/JuliaGL/ModernGL.jl/blob/master/.gitignore
and it is created by `deps/build.jl`