### PR TITLE
Zero initalize ptr_ref

### DIFF
--- a/src/functionloading.jl
+++ b/src/functionloading.jl
@@ -56,7 +56,7 @@ macro glfunc(opengl_func)
     end
     ptr_sym = gensym("$(func_name)_func_pointer")
     ret = quote
-        const $ptr_sym = Ref{Ptr{Cvoid}}()
+        const $ptr_sym = Ref{Ptr{Cvoid}}(C_NULL)
         function $func_name($(arg_names...))
             if $ptr_sym[]::Ptr{Cvoid} == C_NULL
                 $ptr_sym[]::Ptr{Cvoid} = $ptr_expr


### PR DESCRIPTION
See the analysis in https://github.com/JuliaLang/julia/issues/48844#issuecomment-1455156919

`Ref{Ptr{Cvoid}}()` returns un-initialized memory.