### PR TITLE
rm deps/build.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,0 @@
-debug_level = lowercase(get(ENV, "MODERNGL_DEBUGGING", "false")) == "true"
-open(joinpath(@__DIR__, "deps.jl"), "w") do io
-    println(io, "const enable_opengl_debugging = $debug_level")
-end

--- a/src/functionloading.jl
+++ b/src/functionloading.jl
@@ -1,6 +1,8 @@
 const depsfile = normpath(joinpath(@__DIR__, "..", "deps", "deps.jl"))
 
 if isfile(depsfile)
+    # to change create this file with
+    # const enable_opengl_debugging = true/false
     include(depsfile)
 else
     const enable_opengl_debugging = get(ENV, "MODERNGL_DEBUGGING", "false") == "true"

--- a/src/functionloading.jl
+++ b/src/functionloading.jl
@@ -1,18 +1,25 @@
-const depsfile = normpath(joinpath(@__DIR__, "..", "deps", "deps.jl"))
+function should_enable_opengl_debugging()
+    v = get(ENV, "MODERNGL_DEBUGGING", "false")
+    if v in ("true", "false")
+        return v == "true"
+    else
+        error("MODERNGL_DEBUGGING must be either 'true' or 'false'.")
+    end
+end
 
-if isfile(depsfile)
-    # to change create this file with
-    # const enable_opengl_debugging = true/false
-    include(depsfile)
-else
-    const enable_opengl_debugging = get(ENV, "MODERNGL_DEBUGGING", "false") == "true"
+# decide this early here to debug any workload precompilation *in this package* before __init__ is run
+enable_opengl_debugging::Ref{Bool} = Ref(should_enable_opengl_debugging())
+
+function __init__()
+    # the env var may have changed since precompilation
+    enable_opengl_debugging[] = should_enable_opengl_debugging()
 end
 
 gl_represent(x::GLenum) = GLENUM(x).name
 gl_represent(x) = repr(x)
 
 function debug_opengl_expr(func_name, args)
-    if enable_opengl_debugging && func_name != :glGetError
+    if enable_opengl_debugging[] && func_name != :glGetError
         quote
             err = glGetError()
             if err != GL_NO_ERROR

--- a/src/functionloading.jl
+++ b/src/functionloading.jl
@@ -8,7 +8,7 @@ function should_enable_opengl_debugging()
 end
 
 # decide this early here to debug any workload precompilation *in this package* before __init__ is run
-enable_opengl_debugging = Ref{Bool}(should_enable_opengl_debugging())
+const enable_opengl_debugging = Ref{Bool}(should_enable_opengl_debugging())
 
 function __init__()
     # the env var may have changed since precompilation

--- a/src/functionloading.jl
+++ b/src/functionloading.jl
@@ -8,7 +8,7 @@ function should_enable_opengl_debugging()
 end
 
 # decide this early here to debug any workload precompilation *in this package* before __init__ is run
-enable_opengl_debugging::Ref{Bool} = Ref(should_enable_opengl_debugging())
+enable_opengl_debugging = Ref{Bool}(should_enable_opengl_debugging())
 
 function __init__()
     # the env var may have changed since precompilation


### PR DESCRIPTION
I don't understand why this is done during the build step with a fall back to the precompile step.

Seems wasteful to do it during build, especially given it causes re-precompilation if the user calls `Pkg.build`

If it's for development purposes, then this PR should still work.

@SimonDanisch 
